### PR TITLE
fix 4th maze

### DIFF
--- a/mazes.txt
+++ b/mazes.txt
@@ -34,7 +34,7 @@ aaa    aaa      a  aaa   aa a
    a  a   aaaa   a   a   a a  a          
    a  a      aa  aa  aaaaa a  a          
    a  aa      a   aaa     aa  a          
-  aa   aa   aa      a   aaa   a          
+  aa   aa   aaa     a   aaa   a          
   a     aa  a  aaa  a   a  aaaa          
   a      a  aaaa aaaa   aaaa             
   aaaaaaaa


### PR DESCRIPTION
The 4th maze was missing an "a" making it impossible to go from the 43rd to 44th step without hitting white-space.